### PR TITLE
Support X-Real-IP header

### DIFF
--- a/reverseproxy/plugin.php
+++ b/reverseproxy/plugin.php
@@ -17,6 +17,8 @@ function reverseproxy_get_ip( $ip ) {
 		$ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
 	} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	} elseif ( isset ( $_SERVER['HTTP_X_REAL_IP'] ) ) {
+		$ip = $_SERVER['HTTP_X_REAL_IP'];
 	}
 	return yourls_sanitize_ip( $ip );
 }

--- a/reverseproxy/plugin.php
+++ b/reverseproxy/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: ReverseProxy
 Plugin URI: https://github.com/Diftraku/yourls_cloudflare/
 Description: Fixes incoming IPs to use the client IP from reverse proxies
-Version: 2.0
+Version: 2.1
 Author: Diftraku
 */
 


### PR DESCRIPTION
I've noticed that your plugin was only supporting Cloudflare-specific `CF-Connecting-IP` and a bit more standard `X-Forwarded-For`, however there are many reverse proxies which are using the `X-Real-IP`, which isn't supported. This PR changes that and adds this header too, as the last in chain.